### PR TITLE
Drop membership in rmw_implementation_packages group

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -43,8 +43,6 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
-  <member_of_group>rmw_implementation_packages</member_of_group>
-
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/rpm/template.spec.em
+++ b/rpm/template.spec.em
@@ -1,3 +1,8 @@
+@{
+# Drop membership in rmw_implementation_packages group
+Provides = [p for p in Provides if p != 'ros-rolling-rmw-implementation-packages(member)']
+Supplements = [p for p in Supplements if p != 'ros-rolling-rmw-implementation-packages(all)']
+}@
 %bcond_without tests
 %bcond_without weak_deps
 


### PR DESCRIPTION
Since this package compiles as an empty package due to the absence of RTI Connext, it shouldn't be considered a valid member of the `rmw_implementation_packages` group.

Because we're relying on the group membership information expressed as virtual package names to support requiring "any one or more" of the RMW providers to be installed, we have to make sure that this package doesn't advertise that it provides that capability.

A better solution would be to exclude this package from being built as an RPM entirely, but that would require some changes to `ros_buildfarm` to support ignoring a package. If we just added this package to the exclude list, all of the downstream consumers of the package would also get excluded. Because of the "pre-resolution" of groups happening in the `package.xml` for many packages, the buildfarm thinks that this package is upstream of the vast majority of ROS 2. So for now, it is easier to just let the buildfarm build the empty package (with this patch).

**NOTE**: If this PR is squash-merged, be sure to drop the PR number from the end of the commit message, or every time this patch is re-applied by Bloom, it will be back-linked from this PR.